### PR TITLE
json_gen: Add support for int64 values

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Include the C and H files in your project's build system and that should be enou
 ```text
 ./json_gen 
 Creating JSON string [may require Line wrap enabled on console]
-Expected: {"first_bool":true,"first_int":30,"float_val":54.16430,"my_str":"new_name","null_obj":null,"arr":[["arr_string",false,45.12000,null,25,{"arr_obj_str":"sample"}]],"my_obj":{"only_val":5}}
-Generated: {"first_bool":true,"first_int":30,"float_val":54.16430,"my_str":"new_name","null_obj":null,"arr":[["arr_string",false,45.12000,null,25,{"arr_obj_str":"sample"}]],"my_obj":{"only_val":5}}
+Expected: {"first_bool":true,"first_int":30,"first_int64":-102030405060708090,"float_val":54.16430,"my_str":"new_name","null_obj":null,"arr":[["arr_string",false,45.12000,null,25,908070605040302010,{"arr_obj_str":"sample"}]],"my_obj":{"only_val":5}}
+Generated: {"first_bool":true,"first_int":30,"first_int64":-102030405060708090,"float_val":54.16430,"my_str":"new_name","null_obj":null,"arr":[["arr_string",false,45.12000,null,25,908070605040302010,{"arr_obj_str":"sample"}]],"my_obj":{"only_val":5}}
 Test Passed!
 ```
 

--- a/json_generator.c
+++ b/json_generator.c
@@ -219,6 +219,26 @@ int json_gen_arr_set_int(json_gen_str_t *jstr, int val)
 	return json_gen_set_int(jstr, val);
 }
 
+static int json_gen_set_int64(json_gen_str_t *jstr, int64_t val)
+{
+	jstr->comma_req = true;
+	char str[MAX_INT_IN_STR];
+	snprintf(str, MAX_INT_IN_STR, "%lld", val);
+	return json_gen_add_to_str(jstr, str);
+}
+
+int json_gen_obj_set_int64(json_gen_str_t *jstr, const char *name, int64_t val)
+{
+	json_gen_handle_comma(jstr);
+	json_gen_handle_name(jstr, name);
+	return json_gen_set_int64(jstr, val);
+}
+
+int json_gen_arr_set_int64(json_gen_str_t *jstr, int64_t val)
+{
+	json_gen_handle_comma(jstr);
+	return json_gen_set_int64(jstr, val);
+}
 
 static int json_gen_set_float(json_gen_str_t *jstr, float val)
 {

--- a/json_generator.h
+++ b/json_generator.h
@@ -297,6 +297,25 @@ int json_gen_obj_set_bool(json_gen_str_t *jstr, const char *name, bool val);
  */
 int json_gen_obj_set_int(json_gen_str_t *jstr, const char *name, int val);
 
+/** Add an int64 (long long integer) element to an object
+ *
+ * This adds an integer element to an object. Eg. "int64_val":28
+ *
+ * \note This must be called between json_gen_start_object()/json_gen_push_object()
+ * and json_gen_end_object()/json_gen_pop_object()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] name Name of the element
+ * \param[in] val int64 (long long integer) value of the element
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_obj_set_int64(json_gen_str_t *jstr, const char *name, int64_t val);
+
 /** Add a float element to an object
  *
  * This adds a float element to an object. Eg. "float_val":23.8
@@ -384,6 +403,22 @@ int json_gen_arr_set_bool(json_gen_str_t *jstr, bool val);
  * added after that
  */
 int json_gen_arr_set_int(json_gen_str_t *jstr, int val);
+
+/** Add a int64 (long long integer) element to an array
+ *
+ * \note This must be called between json_gen_start_array()/json_gen_push_array()
+ * and json_gen_end_array()/json_gen_pop_array()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] val int64 (long long integer) value of the element
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_arr_set_int64(json_gen_str_t *jstr, int64_t val);
 
 /** Add a float element to an array
  *

--- a/test.c
+++ b/test.c
@@ -19,9 +19,10 @@
 #include <json_generator.h>
 
 static const char expected_str[] = "{\"first_bool\":true,\"first_int\":30,"\
-        "\"float_val\":54.16430,\"my_str\":\"new_name\",\"null_obj\":null,"\
-        "\"arr\":[[\"arr_string\",false,45.12000,null,25,{\"arr_obj_str\":\"sample\"}]],"\
-        "\"my_obj\":{\"only_val\":5}}";
+        "\"first_int64\":-102030405060708090,\"float_val\":54.16430,"\
+        "\"my_str\":\"new_name\",\"null_obj\":null,\"arr\":[[\"arr_string\","\
+        "false,45.12000,null,25,908070605040302010,{\"arr_obj_str\":\"sample\""\
+        "}]],\"my_obj\":{\"only_val\":5}}";
 
 typedef struct {
     char buf[256];
@@ -44,11 +45,12 @@ static void flush_str(char *buf, void *priv)
 {
     "first_bool": true,
     "first_int": 30,
+    "first_int64": -102030405060708090,
     "float_val": 54.1643,
     "my_str": "new_name",
     "null_obj": null,
     "arr": [
-            ["arr_string", false, 45.2, null, 25, {
+            ["arr_string", false, 45.2, null, 25, 908070605040302010, {
              "arr_obj_str": "sample"
              }]
             ],
@@ -67,6 +69,7 @@ static int json_gen_perform_test(json_gen_test_result_t *result, const char *exp
 	json_gen_start_object(&jstr);
 	json_gen_obj_set_bool(&jstr, "first_bool", true);
 	json_gen_obj_set_int(&jstr, "first_int", 30);
+	json_gen_obj_set_int64(&jstr, "first_int64", -102030405060708090);
 	json_gen_obj_set_float(&jstr, "float_val", 54.1643);
 	json_gen_obj_set_string(&jstr, "my_str", "new_name");
 	json_gen_obj_set_null(&jstr, "null_obj");
@@ -77,6 +80,7 @@ static int json_gen_perform_test(json_gen_test_result_t *result, const char *exp
 	json_gen_arr_set_float(&jstr, 45.12);
 	json_gen_arr_set_null(&jstr);
 	json_gen_arr_set_int(&jstr, 25);
+	json_gen_arr_set_int64(&jstr, 908070605040302010);
 	json_gen_start_object(&jstr);
 	json_gen_obj_set_string(&jstr, "arr_obj_str", "sample");
 	json_gen_end_object(&jstr);


### PR DESCRIPTION
This PR adds support for int64 (long long integer) values.

This will better align json_generator with the espressif json_parser (which supports int64).

My specific use-case was trying to add a Unix time to JSON which would not fit in an int.

Thanks, Darian