### PR TITLE
json_gen: Add support for float NaN and Inf values

### DIFF
--- a/json_generator.c
+++ b/json_generator.c
@@ -14,6 +14,7 @@
  *   limitations under the License.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -223,7 +224,7 @@ static int json_gen_set_int64(json_gen_str_t *jstr, int64_t val)
 {
 	jstr->comma_req = true;
 	char str[MAX_INT_IN_STR];
-	snprintf(str, MAX_INT_IN_STR, "%lld", val);
+    snprintf(str, MAX_INT_IN_STR, "%" PRId64, val);
 	return json_gen_add_to_str(jstr, str);
 }
 
@@ -247,16 +248,35 @@ static int json_gen_set_float(json_gen_str_t *jstr, float val)
 	snprintf(str, MAX_FLOAT_IN_STR, "%.*f", JSON_FLOAT_PRECISION, val);
 	return json_gen_add_to_str(jstr, str);
 }
+static int json_gen_set_null(json_gen_str_t *jstr)
+{
+	jstr->comma_req = true;
+	return json_gen_add_to_str(jstr, "null");
+}
 int json_gen_obj_set_float(json_gen_str_t *jstr, const char *name, float val)
 {
 	json_gen_handle_comma(jstr);
 	json_gen_handle_name(jstr, name);
-	return json_gen_set_float(jstr, val);
+    if (isnan(val) || isinf(val))
+    {
+        return json_gen_set_null(jstr);
+    }
+    else
+    {
+	    return json_gen_set_float(jstr, val);
+    }
 }
 int json_gen_arr_set_float(json_gen_str_t *jstr, float val)
 {
 	json_gen_handle_comma(jstr);
-	return json_gen_set_float(jstr, val);
+    if (isnan(val) || isinf(val))
+    {
+        return json_gen_set_null(jstr);
+    }
+    else
+    {
+	    return json_gen_set_float(jstr, val);
+    }
 }
 
 static int json_gen_set_string(json_gen_str_t *jstr, const char *val)
@@ -308,11 +328,6 @@ int json_gen_add_to_long_string(json_gen_str_t *jstr, const char *val)
 int json_gen_end_long_string(json_gen_str_t *jstr)
 {
     return json_gen_add_to_str(jstr, "\"");
-}
-static int json_gen_set_null(json_gen_str_t *jstr)
-{
-	jstr->comma_req = true;
-	return json_gen_add_to_str(jstr, "null");
 }
 int json_gen_obj_set_null(json_gen_str_t *jstr, const char *name)
 {

--- a/json_generator.h
+++ b/json_generator.h
@@ -25,6 +25,7 @@
 #ifndef _JSON_GENERATOR_H
 #define _JSON_GENERATOR_H
 
+#include <math.h>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -319,6 +320,7 @@ int json_gen_obj_set_int64(json_gen_str_t *jstr, const char *name, int64_t val);
 /** Add a float element to an object
  *
  * This adds a float element to an object. Eg. "float_val":23.8
+* If the float value is NaN or Infinity, a null value will be added.
  *
  * \note This must be called between json_gen_start_object()/json_gen_push_object()
  * and json_gen_end_object()/json_gen_pop_object()

--- a/test.c
+++ b/test.c
@@ -20,12 +20,13 @@
 
 static const char expected_str[] = "{\"first_bool\":true,\"first_int\":30,"\
         "\"first_int64\":-102030405060708090,\"float_val\":54.16430,"\
-        "\"my_str\":\"new_name\",\"null_obj\":null,\"arr\":[[\"arr_string\","\
-        "false,45.12000,null,25,908070605040302010,{\"arr_obj_str\":\"sample\""\
+        "\"float_nan\":null,\"float_inf\":null,\"my_str\":\"new_name\","\
+        "\"null_obj\":null,\"arr\":[[\"arr_string\",false,45.12000,null,"\
+        "null,null,25,908070605040302010,{\"arr_obj_str\":\"sample\""\
         "}]],\"my_obj\":{\"only_val\":5}}";
 
 typedef struct {
-    char buf[256];
+    char buf[512];
     size_t offset;
 } json_gen_test_result_t;
 
@@ -47,10 +48,12 @@ static void flush_str(char *buf, void *priv)
     "first_int": 30,
     "first_int64": -102030405060708090,
     "float_val": 54.1643,
+    "float_nan": null,
+    "float_inf": null,
     "my_str": "new_name",
     "null_obj": null,
     "arr": [
-            ["arr_string", false, 45.2, null, 25, 908070605040302010, {
+            ["arr_string", false, 45.2, null, null, null, 25, 908070605040302010, {
              "arr_obj_str": "sample"
              }]
             ],
@@ -71,6 +74,8 @@ static int json_gen_perform_test(json_gen_test_result_t *result, const char *exp
 	json_gen_obj_set_int(&jstr, "first_int", 30);
 	json_gen_obj_set_int64(&jstr, "first_int64", -102030405060708090);
 	json_gen_obj_set_float(&jstr, "float_val", 54.1643);
+	json_gen_obj_set_float(&jstr, "float_nan", NAN);
+	json_gen_obj_set_float(&jstr, "float_inf", INFINITY);
 	json_gen_obj_set_string(&jstr, "my_str", "new_name");
 	json_gen_obj_set_null(&jstr, "null_obj");
 	json_gen_push_array(&jstr, "arr");
@@ -78,6 +83,8 @@ static int json_gen_perform_test(json_gen_test_result_t *result, const char *exp
 	json_gen_arr_set_string(&jstr, "arr_string");
 	json_gen_arr_set_bool(&jstr, false);
 	json_gen_arr_set_float(&jstr, 45.12);
+	json_gen_arr_set_float(&jstr, NAN);
+	json_gen_arr_set_float(&jstr, INFINITY);
 	json_gen_arr_set_null(&jstr);
 	json_gen_arr_set_int(&jstr, 25);
 	json_gen_arr_set_int64(&jstr, 908070605040302010);


### PR DESCRIPTION
If a float value of NaN or Infinte (valid in C) were set, the generated JSON was invalid (`nan` and `inf` were being added as raw values).

As the JSON spec doesn't allow for NaN or Infinite values, these are instead set to `null`.

Now the generated JSON is valid and can be parsed.